### PR TITLE
Add path restrictions to build-oyl3d workflow

### DIFF
--- a/.github/workflows/build-oyl3d.yml
+++ b/.github/workflows/build-oyl3d.yml
@@ -7,6 +7,7 @@ on:
       - 'Source/Premake/**'
       - 'Dependencies.lua'
       - '**premake5.lua'
+      - '.github/workflows/build-oyl3d.yml'
       # TODO: Add oyl spyll dylib to path watch, we might add it to packages. Not sure yet
       # - <path to oyl-spyll dylib>
   pull_request:

--- a/.github/workflows/build-oyl3d.yml
+++ b/.github/workflows/build-oyl3d.yml
@@ -102,14 +102,12 @@ jobs:
           /verbosity:minimal
           ${{ env.solution_file_path }}
 
-
-  win64-msvc:
-    name: MSVC Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
-    # Temporarily disable, we don't plan to support non-clang compilers for the time being
-    # Eventually we will once Oyl Spyll is more fleshed out
-    if: false 
-    runs-on: windows-latest
-    strategy: *build-strategy
-    env:
-      toolset: msc-v143
-    steps: *win64-build-steps
+  # Temporarily disable, we don't plan to support non-clang compilers for the time being
+  # Eventually we will once Oyl Spyll is more fleshed out
+  # win64-msvc:
+  #   name: MSVC Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
+  #   runs-on: windows-latest
+  #   strategy: *build-strategy
+  #   env:
+  #     toolset: msc-v143
+  #   steps: *win64-build-steps

--- a/.github/workflows/build-oyl3d.yml
+++ b/.github/workflows/build-oyl3d.yml
@@ -29,8 +29,8 @@ env:
   vulkan_sdk_version: 1.4.341.1
 
 jobs:
-  win64-msvc:
-    name: MSVC Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
+  win64-clang:
+    name: Clang Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
     runs-on: windows-latest
     strategy: &build-strategy
       fail-fast: false
@@ -41,7 +41,7 @@ jobs:
           - configuration: Distribution
             platform: Editor
     env:
-      toolset: msc-v143
+      toolset: clang
     steps: &win64-build-steps
       - uses: actions/checkout@v6
 
@@ -103,10 +103,13 @@ jobs:
           ${{ env.solution_file_path }}
 
 
-  win64-clang:
-    name: Clang Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
+  win64-msvc:
+    name: MSVC Oyl3D ${{ matrix.platform }} in ${{ matrix.configuration }}
+    # Temporarily disable, we don't plan to support non-clang compilers for the time being
+    # Eventually we will once Oyl Spyll is more fleshed out
+    if: false 
     runs-on: windows-latest
     strategy: *build-strategy
     env:
-      toolset: clang
+      toolset: msc-v143
     steps: *win64-build-steps

--- a/.github/workflows/build-oyl3d.yml
+++ b/.github/workflows/build-oyl3d.yml
@@ -2,8 +2,16 @@ name: Build Oyl3D
 
 on:
   push:
+    paths: &paths-to-watch
+      - 'Source/Oyl3D/**'
+      - 'Source/Premake/**'
+      - 'Dependencies.lua'
+      - '**premake5.lua'
+      # TODO: Add oyl spyll dylib to path watch, we might add it to packages. Not sure yet
+      # - <path to oyl-spyll dylib>
   pull_request:
     branches: ["main"]
+    paths: *paths-to-watch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Only run build-oyl3d workflow if code or project config changes